### PR TITLE
Add basic modular Nightshade framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Nightshade
+
+Nightshade is an interactive red team operations framework written in Bash.
+It uses [gum](https://github.com/charmbracelet/gum) to provide a polished
+command line user interface. The framework is modular and each major
+capability is implemented in a separate script within `nightshade/modules`.
+
+## Features
+
+- Pre-Op tools such as MAC address changes and IP display
+- Reconnaissance helpers using `whois` and `nmap`
+- Placeholder modules for attack, evasion, exploitation and post-exploitation
+
+## Usage
+
+Run the main launcher:
+
+```bash
+./nightshade/nightshade.sh
+```
+
+Nightshade will check for required dependencies on first run and attempt to
+install `gum` if it is missing.

--- a/nightshade/modules/attack.sh
+++ b/nightshade/modules/attack.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+attack_menu() {
+    gum format "# Attack Module\nSelect an exploit tool" >/dev/null
+    gum confirm "No attack tools implemented yet. Press Enter" >/dev/null
+}

--- a/nightshade/modules/evasion.sh
+++ b/nightshade/modules/evasion.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+evasion_menu() {
+    gum format "# Evasion Module" >/dev/null
+    gum confirm "No evasion techniques implemented yet. Press Enter" >/dev/null
+}

--- a/nightshade/modules/exploitation.sh
+++ b/nightshade/modules/exploitation.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+exploitation_menu() {
+    gum format "# Exploitation Module" >/dev/null
+    gum confirm "No exploitation techniques implemented yet. Press Enter" >/dev/null
+}

--- a/nightshade/modules/postex.sh
+++ b/nightshade/modules/postex.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+postex_menu() {
+    gum format "# Post-Exploitation Module" >/dev/null
+    gum confirm "No post-exploitation tools implemented yet. Press Enter" >/dev/null
+}

--- a/nightshade/modules/preop.sh
+++ b/nightshade/modules/preop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+change_mac() {
+    iface=$(gum input --placeholder "Interface (e.g., wlan0)")
+    [ -z "$iface" ] && { echo "No interface provided"; return; }
+    newmac=$(gum input --placeholder "Random if blank")
+    if [ -z "$newmac" ]; then
+        sudo macchanger -r "$iface"
+    else
+        sudo macchanger -m "$newmac" "$iface"
+    fi
+    gum confirm "Press Enter to continue" >/dev/null
+}
+
+show_ip() {
+    hostname -I | gum format
+    gum confirm "Press Enter to continue" >/dev/null
+}
+
+preop_menu() {
+    while true; do
+        choice=$(gum choose "Change MAC" "My IP" "Back")
+        case "$choice" in
+            "Change MAC") change_mac ;;
+            "My IP") show_ip ;;
+            "Back") break ;;
+        esac
+    done
+}

--- a/nightshade/modules/recon.sh
+++ b/nightshade/modules/recon.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+gather_domain() {
+    domain=$(gum input --placeholder "example.com")
+    [ -z "$domain" ] && { echo "No domain provided"; return; }
+    echo "[+] Running whois on $domain" | gum format
+    whois "$domain" | head -n 20
+    gum confirm "Press Enter to continue" >/dev/null
+}
+
+scan_network() {
+    range=$(gum input --placeholder "Network range (192.168.1.0/24)")
+    [ -z "$range" ] && { echo "No range provided"; return; }
+    echo "[+] Scanning $range" | gum format
+    sudo nmap -F "$range"
+    gum confirm "Press Enter to continue" >/dev/null
+}
+
+recon_menu() {
+    while true; do
+        choice=$(gum choose "Gather Intel" "Scan Network" "Back")
+        case "$choice" in
+            "Gather Intel") gather_domain ;;
+            "Scan Network") scan_network ;;
+            "Back") break ;;
+        esac
+    done
+}

--- a/nightshade/nightshade.sh
+++ b/nightshade/nightshade.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Nightshade main menu
+
+set -e
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$BASE_DIR/modules"
+
+# Load modules
+for mod in "$MODULE_DIR"/*.sh; do
+  [ -f "$mod" ] && source "$mod"
+done
+
+# Dependency check
+check_dependencies() {
+    local missing=()
+    command -v gum >/dev/null 2>&1 || missing+=(gum)
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "Installing missing dependencies: ${missing[*]}" >&2
+        sudo apt-get update && sudo apt-get install -y ${missing[*]}
+    fi
+}
+
+main_menu() {
+    while true; do
+        choice=$(gum choose --cursor.foreground 212 --header "Select an option" \
+            "Pre-Op" "Recon" "Attack" "Evasion" "Exploitation" "Post-Ex" "Quit")
+        case "$choice" in
+            "Pre-Op") preop_menu ;;
+            "Recon") recon_menu ;;
+            "Attack") attack_menu ;;
+            "Evasion") evasion_menu ;;
+            "Exploitation") exploitation_menu ;;
+            "Post-Ex") postex_menu ;;
+            "Quit") break ;;
+        esac
+    done
+}
+
+check_dependencies
+main_menu


### PR DESCRIPTION
## Summary
- add interactive `nightshade.sh` launcher using gum
- implement Pre-Op and Recon modules
- add placeholder modules for Attack, Evasion, Exploitation and Post-Ex
- update README with usage and features

## Testing
- `bash -n nightshade/nightshade.sh`
- `bash -n nightshade/modules/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68404ae7d4948324b6daaf4ea48ba129